### PR TITLE
chore: lowercase namespace and table names for compatibility

### DIFF
--- a/target_iceberg/sinks.py
+++ b/target_iceberg/sinks.py
@@ -93,8 +93,9 @@ class IcebergSink(BatchSink):
         # client.upload(context["file_path"])  # Upload file
         # Path(context["file_path"]).unlink()  # Delete local copy
 
-        namespace = self.config.get("namespace")
-        table_name = self.stream_name
+        # use lower case to maximize compatibility with query engines
+        namespace = str(self.config.get("namespace")).lower()
+        table_name = self.stream_name.lower()
         table_id = f"{namespace}.{table_name}"
 
         try:


### PR DESCRIPTION
Trino can't handle cases in Iceberg namespaces and table names.